### PR TITLE
New Line for Checksum Failure

### DIFF
--- a/checksum.cpp
+++ b/checksum.cpp
@@ -1,8 +1,4 @@
-#include "crypt.h"
 #include "checksum.h"
-#include <memory.h>
-#include <stdlib.h>
-#include <stdio.h>
 
 /*
 data checksums
@@ -30,7 +26,7 @@ Just to re-iterate, the encryption is applied AFTER all this checksum mess is do
 // CCITT CRC Code
 // Update the CRC for transmitted and received data using
 // the CCITT 16bit algorithm (X^16 + X^12 + X^5 + 1).
-static unsigned short UpdateCcittCrc16(unsigned short crc16, unsigned char data)
+ unsigned short Checksum::UpdateCcittCrc16(unsigned short crc16, unsigned char data)
 {
 	unsigned short num2 = (unsigned short) (data << 8);
 	for (unsigned int i = 0; i < 8; i++)
@@ -50,7 +46,7 @@ static unsigned short UpdateCcittCrc16(unsigned short crc16, unsigned char data)
 	return crc16;
 }
 
-unsigned short ComputeCcittCrc16(void const* data, unsigned int bytes)
+unsigned short Checksum::ComputeCcittCrc16(void const* data, unsigned int bytes)
 {
 	unsigned short crc = 0xffff;
 	unsigned char const* numPtr = (unsigned char const*)data;
@@ -61,7 +57,7 @@ unsigned short ComputeCcittCrc16(void const* data, unsigned int bytes)
 	return crc;
 }
 
-static bool getChecksumParameters(int checksumType, unsigned int* checksumOffset, unsigned int* dataOffset, unsigned int* dataLength)
+ bool Checksum::getChecksumParameters(int checksumType, unsigned int* checksumOffset, unsigned int* dataOffset, unsigned int* dataLength)
 {
 	switch (checksumType)
 	{
@@ -107,12 +103,15 @@ static bool getChecksumParameters(int checksumType, unsigned int* checksumOffset
 	return true;
 }
 
-static bool computeChecksum(int type, void const* memoryIn, unsigned short* checksum)
+ bool Checksum::computeChecksum(int type, void const* memoryIn, unsigned short* checksum)
 {
 	unsigned int startBlock;
 	unsigned int cntBlock;
 	unsigned int block;
 	unsigned char const* numPtr = (unsigned char const*)memoryIn;
+	
+	Crypt crypt;
+	
 	if ((type == 0) || (type == 1))
 	{
 		unsigned int dataLength;
@@ -165,7 +164,7 @@ static bool computeChecksum(int type, void const* memoryIn, unsigned short* chec
 			block = startBlock + cntBlock;
 			break;
 		}
-		if (!IsAccessControlBlock(block))
+		if (!crypt.IsAccessControlBlock(block))
 		{
 			for (unsigned int i = 0; i < 0x10; i++)
 			{
@@ -179,7 +178,7 @@ static bool computeChecksum(int type, void const* memoryIn, unsigned short* chec
 	// Pad Type 3 checksum with 0x0E blocks of zeroes
 	while (block < 0x1c)
 	{
-		if (!IsAccessControlBlock(block))
+		if (!crypt.IsAccessControlBlock(block))
 		{
 			for (unsigned int j = 0; j < 0x10; j++)
 			{
@@ -201,7 +200,7 @@ static bool computeChecksum(int type, void const* memoryIn, unsigned short* chec
 // overwrite: if true, replace checksum in buffer with newly computed checksum
 //
 // returns true if old checksum in buffer matches computed checksum.
-bool validateChecksum(unsigned char *buffer, int type, int dataArea, bool overwrite)
+bool Checksum::validateChecksum(unsigned char *buffer, int type, int dataArea, bool overwrite)
 {
 	unsigned int checksumOffset;
 	unsigned int areaSequenceOffset;
@@ -256,7 +255,7 @@ bool validateChecksum(unsigned char *buffer, int type, int dataArea, bool overwr
 	return match;
 }
 
-bool ValidateAllChecksums(unsigned char *buffer, bool overwrite)
+bool Checksum::ValidateAllChecksums(unsigned char *buffer, bool overwrite)
 {
 	bool OK = true;
 	bool res;
@@ -271,20 +270,10 @@ bool ValidateAllChecksums(unsigned char *buffer, bool overwrite)
 		for(type = 3; type >=0; type--) {
 			res = validateChecksum(buffer, type, dataArea, overwrite);
 			if(!res && !overwrite) {
-				fprintf(stderr, "Checksum failure for checksum type %d, data area %d", type, dataArea);
+				fprintf(stderr, "Checksum failure for checksum type %d, data area %d\n", type, dataArea);
 			}
 			OK = OK && res;
 		}
 	}
 	return OK;
 }
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I added a new line character for Checksum Failure messages from the console window.

Changes this:
Checksum failure for checksum type 3, data area 0Checksum failure for checksum type 2, data area 0Checksum failure for checksum type 1, data area 0Checksum failure for checksum type 3, data area 1Checksum failure for checksum type 2, data area 1Checksum failure for checksum type 1, data area 1Warning. Skylander data read from portal, but checksums are incorrect.  File may be corrupt.

To:
Checksum failure for checksum type 3, data area 0
Checksum failure for checksum type 2, data area 0
Checksum failure for checksum type 1, data area 0
Checksum failure for checksum type 3, data area 1
Checksum failure for checksum type 2, data area 1
Checksum failure for checksum type 1, data area 1
Warning. Skylander data read from portal, but checksums are incorrect.  File may be corrupt.

This should be cross platform compatible as well.